### PR TITLE
Expand CI test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,12 +7,16 @@ on:
 
 jobs:
   unit:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.11", "3.10", "3.9"]
+        platform: ["ubuntu-latest", "ubuntu-24.04-arm", "macos-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-      - run: pip install -r requirements.txt
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install -r requirements.txt
       - run: flake8 . || true
       - run: pytest -q -m "not integration" --cov=. --cov-report=term-missing


### PR DESCRIPTION
## Summary
- run CI tests across Python 3.9–3.12 and all major OSes

## Testing
- `pytest -q`
- `pyenv shell 3.10.17 && pytest -q`
- `pyenv shell 3.12.10 && pytest -q`
- `pyenv shell 3.13.3 && pytest -q`
- `pyenv install 3.9.21` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bf32c7b17c833184dd7389550e0a48