### PR TITLE
Add folder watcher service and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,41 @@ py web_to_cookbook.py -u https://example.com -i "Wi-Fi"
 
 The script creates a subdirectory for each recipe inside the target folder containing `recipe.json` and `full.jpg`.
 
+## Background folder watcher
+You can process recipes automatically by watching a directory for new files. Each
+file should either contain a single URL or a block of HTML. New files are parsed
+and passed to `web_to_cookbook.py` automatically.
+
+### Run directly
+```bash
+python watch_folder.py /path/to/incoming /path/to/parsed_recipes
+```
+
+### Using systemd (Linux)
+Create `/etc/systemd/system/recipe-watcher.service`:
+
+```ini
+[Unit]
+Description=Watch a folder and parse recipes
+
+[Service]
+Type=simple
+ExecStart=/path/to/watch_folder.sh /path/to/incoming /path/to/parsed_recipes
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start the service:
+
+```bash
+sudo systemctl enable --now recipe-watcher.service
+```
+
+On Windows or macOS you can run `watch_folder.py` using a similar startup
+mechanism such as Task Scheduler or `launchd`.
+
 ## Running tests
 To ensure the project works correctly after changes, run:
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ netifaces2==0.0.22
 pytest-cov==5.0.0
 flake8==7.1.1
 curl-cffi==0.13.0
+watchdog==4.0.0

--- a/tests/test_watch_folder.py
+++ b/tests/test_watch_folder.py
@@ -17,7 +17,7 @@ def test_process_file_url(tmp_path, monkeypatch):
     monkeypatch.setattr(wtc, "URLToCookbook", DummyURL)
 
     file_path = tmp_path / "url.txt"
-    file_path.write_text("http://example.com")
+    file_path.write_text("link: http://example.com end")
 
     watch_folder.process_file(file_path, tmp_path)
 
@@ -46,6 +46,27 @@ def test_process_file_html(tmp_path, monkeypatch):
     assert called["run"]
 
 
+def test_process_file_multiple_urls(tmp_path, monkeypatch):
+    called = {}
+
+    class DummyURL:
+        def __init__(self, url_list, target_folder, interface=""):
+            called["url_list"] = url_list
+
+        def run_through_urls(self):
+            called["run"] = True
+
+    monkeypatch.setattr(wtc, "URLToCookbook", DummyURL)
+
+    file_path = tmp_path / "urls.txt"
+    file_path.write_text("one http://example.com two https://foo.bar")
+
+    watch_folder.process_file(file_path, tmp_path)
+
+    assert called["url_list"] == ["http://example.com", "https://foo.bar"]
+    assert called["run"]
+
+
 def test_watch_directory(tmp_path, monkeypatch):
     called = {}
 
@@ -67,7 +88,7 @@ def test_watch_directory(tmp_path, monkeypatch):
 
     try:
         file_path = watch_dir / "url.txt"
-        file_path.write_text("http://example.com")
+        file_path.write_text("here: http://example.com")
         # wait for the observer to pick up the event
         for _ in range(10):
             if called.get("run"):

--- a/tests/test_watch_folder.py
+++ b/tests/test_watch_folder.py
@@ -1,0 +1,80 @@
+import time
+
+import watch_folder
+import web_to_cookbook as wtc
+
+
+def test_process_file_url(tmp_path, monkeypatch):
+    called = {}
+
+    class DummyURL:
+        def __init__(self, url_list, target_folder, interface=""):
+            called["url_list"] = url_list
+
+        def run_through_urls(self):
+            called["run"] = True
+
+    monkeypatch.setattr(wtc, "URLToCookbook", DummyURL)
+
+    file_path = tmp_path / "url.txt"
+    file_path.write_text("http://example.com")
+
+    watch_folder.process_file(file_path, tmp_path)
+
+    assert called["url_list"] == ["http://example.com"]
+    assert called["run"]
+
+
+def test_process_file_html(tmp_path, monkeypatch):
+    called = {}
+
+    class DummyHTML:
+        def __init__(self, html_list, target_folder, interface=""):
+            called["html_list"] = html_list
+
+        def run_through_htmls(self):
+            called["run"] = True
+
+    monkeypatch.setattr(wtc, "HTMLToCookbook", DummyHTML)
+
+    file_path = tmp_path / "page.html"
+    file_path.write_text("<html><body>Hi</body></html>")
+
+    watch_folder.process_file(file_path, tmp_path)
+
+    assert "<html>" in called["html_list"][0]
+    assert called["run"]
+
+
+def test_watch_directory(tmp_path, monkeypatch):
+    called = {}
+
+    class DummyURL:
+        def __init__(self, url_list, target_folder, interface=""):
+            called["url_list"] = url_list
+
+        def run_through_urls(self):
+            called["run"] = True
+
+    monkeypatch.setattr(wtc, "URLToCookbook", DummyURL)
+
+    watch_dir = tmp_path / "incoming"
+    watch_dir.mkdir()
+    target = tmp_path / "out"
+    target.mkdir()
+
+    observer = watch_folder.watch_directory(watch_dir, target)
+
+    try:
+        file_path = watch_dir / "url.txt"
+        file_path.write_text("http://example.com")
+        # wait for the observer to pick up the event
+        for _ in range(10):
+            if called.get("run"):
+                break
+            time.sleep(0.2)
+        assert called["url_list"] == ["http://example.com"]
+        assert called["run"]
+    finally:
+        observer.stop()
+        observer.join()

--- a/watch_folder.py
+++ b/watch_folder.py
@@ -7,14 +7,24 @@ import web_to_cookbook as wtc
 
 
 def process_file(file_path: Path, target_folder: Path, interface: str = "") -> None:
-    """Process a file containing a recipe URL or raw HTML.
+    """Process a file containing recipe URLs or raw HTML.
 
-    The file's text content is forwarded to :func:`web_to_cookbook.process_text`
-    which handles dispatching to the appropriate parser based on whether the
-    content looks like HTML or a URL.
+    If the file contains HTML (detected by a ``<html`` tag) it is parsed
+    directly. Otherwise any URLs within the file are extracted using
+    :func:`web_to_cookbook.get_urls_from_file` and each URL is parsed. Extra
+    text surrounding the URLs is ignored.
     """
-    text = file_path.read_text(encoding="utf-8")
-    wtc.process_text(text, target_folder, interface)
+    contents = file_path.read_text(encoding="utf-8").strip()
+    if "<html" in contents.lower():
+        parser = wtc.HTMLToCookbook(html_list=[contents], target_folder=target_folder, interface=interface)
+        parser.run_through_htmls()
+    else:
+        urls = wtc.get_urls_from_file(file_path)
+        urls = [url.strip() for url in urls if url.strip()]
+        if not urls:
+            return
+        parser = wtc.URLToCookbook(url_list=urls, target_folder=target_folder, interface=interface)
+        parser.run_through_urls()
 
 
 class RecipeFileHandler(FileSystemEventHandler):

--- a/watch_folder.py
+++ b/watch_folder.py
@@ -7,19 +7,14 @@ import web_to_cookbook as wtc
 
 
 def process_file(file_path: Path, target_folder: Path, interface: str = "") -> None:
-    """Process a file that contains either a URL or raw HTML.
+    """Process a file containing a recipe URL or raw HTML.
 
-    If the file text contains ``<html`` it is treated as HTML and passed to
-    :class:`web_to_cookbook.HTMLToCookbook`. Otherwise the content is assumed to
-    be a URL and handled by :class:`web_to_cookbook.URLToCookbook`.
+    The file's text content is forwarded to :func:`web_to_cookbook.process_text`
+    which handles dispatching to the appropriate parser based on whether the
+    content looks like HTML or a URL.
     """
-    text = file_path.read_text(encoding="utf-8").strip()
-    if "<html" in text.lower():
-        parser = wtc.HTMLToCookbook(html_list=[text], target_folder=target_folder, interface=interface)
-        parser.run_through_htmls()
-    else:
-        parser = wtc.URLToCookbook(url_list=[text], target_folder=target_folder, interface=interface)
-        parser.run_through_urls()
+    text = file_path.read_text(encoding="utf-8")
+    wtc.process_text(text, target_folder, interface)
 
 
 class RecipeFileHandler(FileSystemEventHandler):

--- a/watch_folder.py
+++ b/watch_folder.py
@@ -1,0 +1,68 @@
+import argparse
+import time
+from pathlib import Path
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+import web_to_cookbook as wtc
+
+
+def process_file(file_path: Path, target_folder: Path, interface: str = "") -> None:
+    """Process a file that contains either a URL or raw HTML.
+
+    If the file text contains ``<html`` it is treated as HTML and passed to
+    :class:`web_to_cookbook.HTMLToCookbook`. Otherwise the content is assumed to
+    be a URL and handled by :class:`web_to_cookbook.URLToCookbook`.
+    """
+    text = file_path.read_text(encoding="utf-8").strip()
+    if "<html" in text.lower():
+        parser = wtc.HTMLToCookbook(html_list=[text], target_folder=target_folder, interface=interface)
+        parser.run_through_htmls()
+    else:
+        parser = wtc.URLToCookbook(url_list=[text], target_folder=target_folder, interface=interface)
+        parser.run_through_urls()
+
+
+class RecipeFileHandler(FileSystemEventHandler):
+    """Event handler that triggers recipe parsing on new files."""
+
+    def __init__(self, target_folder: Path, interface: str = "") -> None:
+        self.target_folder = target_folder
+        self.interface = interface
+
+    def on_created(self, event):  # type: ignore[override]
+        if event.is_directory:
+            return
+        process_file(Path(event.src_path), self.target_folder, self.interface)
+
+
+def watch_directory(source: Path, target: Path, interface: str = "") -> Observer:
+    """Start watching *source* for new files and process them.
+
+    Returns the :class:`watchdog.observers.Observer` instance so callers can
+    manage its lifecycle (useful for tests).
+    """
+    handler = RecipeFileHandler(target, interface)
+    observer = Observer()
+    observer.schedule(handler, str(source), recursive=False)
+    observer.start()
+    return observer
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Watch a folder for recipe files and parse them")
+    parser.add_argument("source", type=Path, help="Folder to watch for new files")
+    parser.add_argument("target", type=Path, help="Folder to store parsed recipes")
+    parser.add_argument("-i", "--interface", default="", help="Network interface to use")
+    args = parser.parse_args()
+
+    observer = watch_directory(args.source, args.target, args.interface)
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+    observer.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/watch_folder.sh
+++ b/watch_folder.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+# Wrapper to run the folder watcher using the system's python interpreter
+python "$(dirname "$0")/watch_folder.py" "$@"

--- a/web_to_cookbook.py
+++ b/web_to_cookbook.py
@@ -367,6 +367,28 @@ def get_urls_from_file(url_file: Path) -> list[str]:
     return urls
 
 
+def process_text(text: str, target_folder: Path, interface: str = "") -> None:
+    """Process a string containing either a URL or raw HTML.
+
+    The function inspects *text* to determine whether it contains HTML. If
+    ``<html`` is present (case-insensitive), the text is treated as raw HTML
+    and passed to :class:`HTMLToCookbook`. Otherwise the text is assumed to be
+    a single URL and routed to :class:`URLToCookbook`.
+
+    :param text: Source string with either a URL or HTML markup.
+    :param target_folder: Destination folder for the parsed recipe output.
+    :param interface: Optional network interface for outbound requests.
+    """
+
+    text = text.strip()
+    if "<html" in text.lower():
+        parser = HTMLToCookbook(html_list=[text], target_folder=target_folder, interface=interface)
+        parser.run_through_htmls()
+    else:
+        parser = URLToCookbook(url_list=[text], target_folder=target_folder, interface=interface)
+        parser.run_through_urls()
+
+
 if __name__ == "__main__":
     # Command-line argument parser for recipe URLs and files containing URLs
     parser = argparse.ArgumentParser(description="Scrape recipes from URLs or files containing URLs.")


### PR DESCRIPTION
## Summary
- add `watch_folder.py` to monitor a directory for new recipe files and process URLs or HTML
- provide `watch_folder.sh` wrapper and document systemd service setup
- cover directory watcher with unit tests and include `watchdog` dependency

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0866541cc83319d16a13d5d73292f